### PR TITLE
fix training dockerfile failure

### DIFF
--- a/det-yolov4-training/Dockerfile
+++ b/det-yolov4-training/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update
 RUN apt install -y software-properties-common wget
 RUN add-apt-repository ppa:deadsnakes/ppa
 RUN apt-get update
-RUN apt install -y python3.7
+RUN apt install -y python3.7 python3-distutils
 RUN wget https://bootstrap.pypa.io/get-pip.py
 RUN wget https://github.com/AlexeyAB/darknet/releases/download/darknet_yolo_v3_optimal/yolov4.conv.137
 RUN rm /usr/bin/python3


### PR DESCRIPTION
我在 13.107 上重新对训练镜像打包的时候发现会在执行 `RUN python3 get-pip.py` 的时候报错：

```
Step 13/21 : RUN python3 get-pip.py
 ---> Running in 15e7dcc28772
Traceback (most recent call last):
  File "get-pip.py", line 27081, in <module>
    main()
  File "get-pip.py", line 139, in main
    bootstrap(tmpdir=tmpdir)
  File "get-pip.py", line 115, in bootstrap
    monkeypatch_for_cert(tmpdir)
  File "get-pip.py", line 96, in monkeypatch_for_cert
    from pip._internal.commands.install import InstallCommand
  File "/tmp/tmp7i6paohj/pip.zip/pip/_internal/commands/__init__.py", line 9, in <module>
  File "/tmp/tmp7i6paohj/pip.zip/pip/_internal/cli/base_command.py", line 13, in <module>
  File "/tmp/tmp7i6paohj/pip.zip/pip/_internal/cli/cmdoptions.py", line 23, in <module>
  File "/tmp/tmp7i6paohj/pip.zip/pip/_internal/cli/parser.py", line 12, in <module>
  File "/tmp/tmp7i6paohj/pip.zip/pip/_internal/configuration.py", line 26, in <module>
  File "/tmp/tmp7i6paohj/pip.zip/pip/_internal/utils/logging.py", line 13, in <module>
  File "/tmp/tmp7i6paohj/pip.zip/pip/_internal/utils/misc.py", line 40, in <module>
  File "/tmp/tmp7i6paohj/pip.zip/pip/_internal/locations/__init__.py", line 14, in <module>
  File "/tmp/tmp7i6paohj/pip.zip/pip/_internal/locations/_distutils.py", line 9, in <module>
ModuleNotFoundError: No module named 'distutils.cmd'
The command '/bin/sh -c python3 get-pip.py' returned a non-zero code: 1
```

此 pr 修正了这个问题。